### PR TITLE
ci: add github release workflow set

### DIFF
--- a/.github/workflows/create-github-release-commit-message.yml
+++ b/.github/workflows/create-github-release-commit-message.yml
@@ -1,0 +1,11 @@
+name: Create Github Release on Commit Message[create_release]
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  run-create-github-release-action:
+    if: "contains(github.event.head_commit.message, '[create_release]')"
+    uses: x-b-e/internal_shared/.github/workflows/shared-create-github-release-commit-message.yml@main

--- a/.github/workflows/create-github-release-daily.yml
+++ b/.github/workflows/create-github-release-daily.yml
@@ -1,0 +1,22 @@
+name: Create Github Release Daily (on schedule)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '00 13 * * *' #Daily
+
+permissions:
+  contents: write
+  packages: read
+  issues: read
+  pull-requests: read
+  repository-projects: read
+
+jobs:
+  post-to-slack-release-notes-dev:
+    uses: x-b-e/internal_shared/.github/workflows/shared-release-notes-daily.yml@main
+    with:
+      slack_channel_id: 'CB2PJRG1E'
+      report_title: 'Summarize Meeting Daily Release Notes'
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/create-github-release-daily.yml
+++ b/.github/workflows/create-github-release-daily.yml
@@ -15,8 +15,6 @@ permissions:
 jobs:
   post-to-slack-release-notes-dev:
     uses: x-b-e/internal_shared/.github/workflows/shared-release-notes-daily.yml@main
-    with:
-      slack_channel_id: 'CB2PJRG1E'
-      report_title: 'Summarize Meeting Daily Release Notes'
+    with:      report_title: 'Summarize Meeting Daily Release Notes'
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/create-github-release-daily.yml
+++ b/.github/workflows/create-github-release-daily.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   post-to-slack-release-notes-dev:
     uses: x-b-e/internal_shared/.github/workflows/shared-release-notes-daily.yml@main
-    with:      report_title: 'Summarize Meeting Daily Release Notes'
+    with:
+      report_title: 'Summarize Meeting Daily Release Notes'
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/create-github-release-scheduled.yml
+++ b/.github/workflows/create-github-release-scheduled.yml
@@ -1,0 +1,9 @@
+name: Create Github Release Scheduler
+
+on:
+  schedule:
+    - cron: '00 13 * * *'
+
+jobs:
+  run-create-github-release-action:
+    uses: x-b-e/internal_shared/.github/workflows/shared-create-github-release-scheduled.yml@main


### PR DESCRIPTION
Add create-github-release workflow files and wire daily release notes via internal_shared.