### PR TITLE
chore: pin daily release workflow to internal_shared#68

### DIFF
--- a/.github/workflows/create-github-release-daily.yml
+++ b/.github/workflows/create-github-release-daily.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   post-to-slack-release-notes-dev:
-    uses: x-b-e/internal_shared/.github/workflows/shared-release-notes-daily.yml@main
+    uses: x-b-e/internal_shared/.github/workflows/shared-release-notes-daily.yml@b58b9dfa58a1dafdb0093e21dc290f1c7dee5932
     with:
       report_title: 'Summarize Meeting Daily Release Notes'
     secrets:


### PR DESCRIPTION
Agent responds:

Pins this repo's daily release workflow to x-b-e/internal_shared@b58b9dfa58a1dafdb0093e21dc290f1c7dee5932 so it picks up the release-note fixes from x-b-e/internal_shared#68 before that upstream PR merges.

Changes:
- update .github/workflows/create-github-release-daily.yml to use x-b-e/internal_shared/.github/workflows/shared-release-notes-daily.yml@b58b9dfa58a1dafdb0093e21dc290f1c7dee5932

Reference:
- x-b-e/internal_shared#68
